### PR TITLE
Add FT232H- D3 pin to control PMM reset when update f/w by I2C

### DIFF
--- a/tools/python/firefly/transport/gateway.py
+++ b/tools/python/firefly/transport/gateway.py
@@ -157,7 +157,17 @@ class GatewayI2C(Gateway):
         return self.timeout
 
     def enter_boot_loader(self):
-        pass
+        D3_PIN = 3
+        port = self.i2c.get_gpio()
+        port.set_direction(pins=(1<<D3_PIN), direction=(1<<D3_PIN)) # config AD3 as output
+        pins = port.read()
+        pins &= ~(1 << D3_PIN) # config AD3 as LOW to trigger reset
+        port.write(pins) 
+        time.sleep(0.25)
+        pins = port.read()
+        pins |= 1 << D3_PIN # config D3 as HIGH to enable PMM
+        port.write(pins) 
+        time.sleep(0.25)
 
     def write(self, data):
         self.port.write(out=data)

--- a/tools/update/controller.py
+++ b/tools/update/controller.py
@@ -365,9 +365,20 @@ class Controller:
         if do_restart:
             self.gateway.enter_boot_loader()
 
-        identity = self.get_identity()
-        version = identity.version
-        print(f"identity: {identity.identifier} {version.major}.{version.minor}.{version.patch}")
+        identity = None
+        for i in range(3): 
+            try:
+                identity = self.get_identity() # transfer 1st dummy frame to detect I2C
+                version = identity.version
+                print(f"identity: {identity.identifier} {version.major}.{version.minor}.{version.patch}")
+                break
+            except:
+                pass
+            
+        if identity == None:
+            print(f"Get identity failed! Retry!")
+            return
+
         if do_version:
             return
 


### PR DESCRIPTION
Summary
PMM needs to be triggered a reset by FT232H automatically and send a package within 1 second to the bootloader, for a more friendly f/w update.

Reviewer
@denisbohm 

Monday URL: https://hellowynd.monday.com/boards/380584598/pulses/4716258553
